### PR TITLE
Update System.Windows.Forms.dll to exclude platforms by default

### DIFF
--- a/Packages/StandaloneFileBrowser/Plugins/System.Windows.Forms.dll.meta
+++ b/Packages/StandaloneFileBrowser/Plugins/System.Windows.Forms.dll.meta
@@ -16,15 +16,23 @@ PluginImporter:
     second:
       enabled: 0
       settings:
+        Exclude Android: 1
         Exclude Editor: 0
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
         Exclude Win: 0
         Exclude Win64: 0
   - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        AndroidSharedLibraryType: Executable
+        CPU: ARMv7
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor


### PR DESCRIPTION
System.Windows.Forms.dll was set to include all platforms. This caused unsupported platforms to fail during build (e.g. Android and iOS). The proposed change limits the DLL to just the supported platforms.